### PR TITLE
chore: migrate ignition-lint to bw-design-group/ignition-lint v0.4.1

### DIFF
--- a/.github/workflows/repo-lint.yml
+++ b/.github/workflows/repo-lint.yml
@@ -48,9 +48,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - name: Run lint-ignition-views.py
-        uses: ia-eknorr/ignition-lint@v2.3
+      - uses: actions/setup-python@v5
         with:
-          files: "**/view.json"
-          component_style: PascalCase
-          parameter_style: camelCase
+          python-version: '3.13'
+      - name: Install ign-lint
+        run: pip install ign-lint==0.4.1
+      - name: Lint Ignition views
+        run: ign-lint --config .ignition-lint.json --files "**/view.json"

--- a/.github/workflows/repo-lint.yml
+++ b/.github/workflows/repo-lint.yml
@@ -52,6 +52,6 @@ jobs:
         with:
           python-version: '3.13'
       - name: Install ign-lint
-        run: pip install ign-lint==0.4.1
+        run: pip install ign-lint==0.5.0
       - name: Lint Ignition views
         run: ign-lint --config .ignition-lint.json --files "**/view.json"

--- a/.github/workflows/repo-lint.yml
+++ b/.github/workflows/repo-lint.yml
@@ -29,7 +29,11 @@ jobs:
         run: |
           npm install -g markdownlint-cli
       - name: Run markdownlint
-        run: 'find . -name "*.md" | xargs markdownlint'
+        run: |
+          markdownlint \
+            --config .lint/.markdownlint.json \
+            --ignore-path .lint/.markdownlintignore \
+            "**/*.md"
 
   yamllint:
     name: Lint YAML files
@@ -37,7 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Run yamllint
-        run: 'find . -name "*.yml" | xargs yamllint'
+        run: 'yamllint -c .lint/.yamllint.yml .'
 
   lint-ignition-views:
     name: Lint Ignition Views

--- a/.ignition-lint.json
+++ b/.ignition-lint.json
@@ -1,0 +1,45 @@
+{
+  "NamePatternRule": {
+    "enabled": true,
+    "kwargs": {
+      "node_type_specific_rules": {
+        "component": {
+          "convention": "PascalCase",
+          "min_length": 3,
+          "severity": "error"
+        },
+        "property": {
+          "convention": "camelCase",
+          "min_length": 2,
+          "severity": "warning"
+        }
+      }
+    }
+  },
+  "PollingIntervalRule": {
+    "enabled": false
+  },
+  "PylintScriptRule": {
+    "enabled": true,
+    "kwargs": {
+      "debug": false,
+      "batch_mode": false
+    }
+  },
+  "UnusedCustomPropertiesRule": {
+    "enabled": true,
+    "kwargs": {}
+  },
+  "ExcessiveContextDataRule": {
+    "enabled": false
+  },
+  "BadComponentReferenceRule": {
+    "enabled": true,
+    "kwargs": {
+      "severity": "error"
+    }
+  },
+  "ComponentReferenceValidationRule": {
+    "enabled": false
+  }
+}

--- a/.lint/.markdownlintignore
+++ b/.lint/.markdownlintignore
@@ -1,4 +1,3 @@
 **/com.inductiveautomation.perspective/**
-pull_request_template.md
-.github/ISSUE_TEMPLATE
+.github/**
 CODEOWNERS

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,3 +40,9 @@ repos:
     hooks:
       - id: yamllint
         args: ["--config-file=.lint/.yamllint.yml", "--format=standard"]
+
+  - repo: https://github.com/bw-design-group/ignition-lint
+    rev: v0.4.1
+    hooks:
+      - id: ign-lint
+        args: ['--config=.ignition-lint.json', '--files']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
         args: ["--config-file=.lint/.yamllint.yml", "--format=standard"]
 
   - repo: https://github.com/bw-design-group/ignition-lint
-    rev: v0.4.1
+    rev: v0.5.0
     hooks:
       - id: ign-lint
         args: ['--config=.ignition-lint.json', '--files']


### PR DESCRIPTION
### 📖 Background
The project now uses the forked and significantly expanded `bw-design-group/ignition-lint` instead of the original `ia-eknorr/ignition-lint`. The new tool is a proper PyPI package with a CLI, pre-commit hook support, and a JSON rule config system.

### ⚙️ Changes
- Replace `ia-eknorr/ignition-lint@v2.3` GitHub Action with `pip install ign-lint==0.4.1` + CLI invocation in the workflow
- Add `bw-design-group/ignition-lint` pre-commit hook to `.pre-commit-config.yaml`
- Add `.ignition-lint.json` with explicit rule configuration:
  - `NamePatternRule`: components = PascalCase (error), custom properties = camelCase (warning)
  - `PylintScriptRule`: enabled - lints embedded Ignition scripts via pylint
  - `UnusedCustomPropertiesRule`: enabled - flags declared but unreferenced custom properties
  - `BadComponentReferenceRule`: enabled (error) - flags brittle `.getSibling()`/`.getParent()` calls
  - `PollingIntervalRule`, `ExcessiveContextDataRule`, `ComponentReferenceValidationRule`: explicitly disabled

### 📝 Reviewer Notes
All rules not currently enabled are listed with `"enabled": false` in the config for self-documentation - it makes it clear which rules exist and were intentionally excluded.

The pre-commit hook overrides the default config arg (`--config=.ignition-lint-precommit.json`) to use the shared `.ignition-lint.json`, so CI and pre-commit use identical rule config.

### ☑️ Testing Notes
- Push a branch with a `view.json` containing a bad component name (e.g. lowercase) and confirm the `Lint Ignition Views` CI job fails
- Run `pre-commit run ign-lint` locally with `ign-lint` installed to verify the hook fires correctly