### PR TITLE
chore: remove release/v1 branch rules from Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,37 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
-  "baseBranchPatterns": ["main", "/^release\\/.*/"],
+  "extends": ["config:recommended"],
   "packageRules": [
     {
-      "description": "Pin publicdemo-workflows to v14.x on release/v1",
-      "matchBaseBranches": ["release/v1"],
-      "matchPackageNames": ["inductive-automation/publicdemo-workflows"],
-      "allowedVersions": "<15.0.0"
-    },
-    {
-      "description": "Allow publicdemo-workflows v15+ on main",
-      "matchBaseBranches": ["main"],
-      "matchPackageNames": ["inductive-automation/publicdemo-workflows"],
-      "allowedVersions": ">=15.0.0"
-    },
-    {
-      "description": "Pin ignition to v8.1.x on release/v1",
-      "matchBaseBranches": ["release/v1"],
-      "matchPackageNames": ["etknorr/common-docker-ignition", "inductiveautomation/ignition"],
-      "allowedVersions": "~8.1.0"
-    },
-    {
-      "description": "Pin ignition to v8.3.x on main",
-      "matchBaseBranches": ["main"],
       "matchPackageNames": ["inductiveautomation/ignition"],
       "allowedVersions": "~8.3.0"
     }
   ],
-  "ignoreDeps": [
-    "mysql",
-    "python"
-  ]
+  "ignoreDeps": ["mysql", "python"]
 }


### PR DESCRIPTION
Strips out the `release/v1` branch patterns and associated version-pinning rules since we no longer maintain that branch. Keeps the 8.3.x Ignition pin and the mysql/python ignoreDeps.