### PR TITLE
add ia-eknorr as reviewer on renovate PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "reviewers": ["ia-eknorr"],
   "packageRules": [
     {
       "matchPackageNames": ["inductiveautomation/ignition"],


### PR DESCRIPTION
### Background

Renovate PRs were being opened with no reviewer assigned, making them easy to miss.

### Changes

- Add `"reviewers": ["ia-eknorr"]` to `.github/renovate.json`