### PR TITLE
add admin credentials env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 GATEWAY_NAME="project-name"
 DB_USER="ignition"
 DB_PASSWORD="ignition"
+GATEWAY_ADMIN_USERNAME="admin"
+GATEWAY_ADMIN_PASSWORD="changeme"
 TZ="America/Los_Angeles"
 DEPLOYMENT_MODE="dev"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,11 @@ instructions.
    cp .env.example .env
    ```
 
-3. Edit `.env` and set `GATEWAY_NAME` to a short identifier (e.g., `dev-gw`)
+3. Edit `.env`:
+   - Set `GATEWAY_NAME` to a short identifier (e.g., `dev-gw`)
+   - Change `GATEWAY_ADMIN_PASSWORD` from the default `changeme` to a password of your choice.
+     `GATEWAY_ADMIN_USERNAME` and `GATEWAY_ADMIN_PASSWORD` are the credentials you will use to
+     log in to the gateway.
 4. Start the stack:
 
    ```shell

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ x-ignition-common: &ignition-common
 x-ignition-environment: &ignition-environment
   ACCEPT_IGNITION_EULA: "Y"
   IGNITION_EDITION: standard
+  GATEWAY_ADMIN_USERNAME: ${GATEWAY_ADMIN_USERNAME}
+  GATEWAY_ADMIN_PASSWORD: ${GATEWAY_ADMIN_PASSWORD}
   TZ: ${TZ}
 
 services:


### PR DESCRIPTION
## Summary

The default user source in `services/ignition/config/resources/core/` ships with a hardcoded admin password hash that nobody knows, so users could not log in after first-start commissioning.

This PR adds `GATEWAY_ADMIN_USERNAME` and `GATEWAY_ADMIN_PASSWORD` env vars to the gateway container. Ignition creates a temp user source overlay on first start with these credentials, so users log in with whatever they set in their `.env` file.

## Changes

- `.env.example`: added `GATEWAY_ADMIN_USERNAME="admin"` and `GATEWAY_ADMIN_PASSWORD="changeme"`
- `docker-compose.yml`: pass both vars into the gateway container via the shared `x-ignition-environment` anchor
- `README.md`: updated Quick Start to direct users to change `GATEWAY_ADMIN_PASSWORD` before bringing the stack up

## Test plan

- [x] `docker compose config` exits 0
- [ ] Fresh clone, set password in `.env`, `docker compose up -d`, log in at `${GATEWAY_NAME}.localtest.me` with the configured credentials