### PR TITLE
open gateway by default + security README

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,13 +130,6 @@ Once both steps are complete, the Gateway requires a valid login for any access:
 anonymous visits to `/app/home`, `/app/platform/security/user-sources`, and the rest of
 the Gateway UI return a "Not Authenticated" prompt or "Page Not Found".
 
-> [!NOTE]
-> `forceIdpAuth` (also in `security-properties/config.json`) does **not** control whether
-> login is required. Per the Ignition docs it controls SSO behavior: when `true`, the
-> Gateway always asks the IdP to re-authenticate the user by default, effectively
-> disabling Single Sign-On. Flipping it does not open or close anonymous access on its
-> own; the permission blocks above are what gate access.
-
 ## Linting
 
 Pull requests run shellcheck, markdownlint, yamllint, and ignition-lint automatically. See the

--- a/README.md
+++ b/README.md
@@ -61,8 +61,10 @@ Changes made in the Ignition Designer appear instantly in these directories - no
 ## Security
 
 By design, this template ships with the Gateway open: no login is required to browse the
-Gateway UI. This avoids the situation where a new user clones the template, brings the stack
-up, and has no way to know what credentials to use.
+Gateway UI. This is the stock behavior of `security-properties/config.json` shipped in this
+repo, where `accessPermissions`, `readPermissions`, and `writePermissions` all use an empty
+`AnyOf` list (no security levels required). It avoids the situation where a new user clones
+the template, brings the stack up, and has no way to know what credentials to use.
 
 The committed admin user still exists in
 `services/ignition/config/resources/core/ignition/user-source/default/users.json`. You only
@@ -70,8 +72,8 @@ need to authenticate for operations that require an `Administrator` role (such a
 the Designer).
 
 > [!WARNING]
-> While `forceIdpAuth` is `false`, the user-management UI is also unauthenticated. Anyone
-> with network access to the Gateway can change the `admin` password through the UI without
+> While the Gateway is open, the user-management UI is also unauthenticated. Anyone with
+> network access to the Gateway can change the `admin` password through the UI without
 > first proving they know the existing one. Treat the open-by-default Gateway as a local
 > development convenience only.
 
@@ -91,13 +93,31 @@ below.
 - Commit the updated `users.json` if you want the new credential baked into the template,
   or leave it in the runtime volume.
 
-**2. Re-enable authentication enforcement.**
+**2. Require authentication on the Gateway.**
 
 Edit `services/ignition/config/resources/core/ignition/security-properties/config.json` and
-set:
+replace the three permission blocks (`accessPermissions`, `readPermissions`,
+`writePermissions`) so they require the `Authenticated` security level:
 
 ```json
-"forceIdpAuth": true
+"accessPermissions": {
+  "securityLevels": [
+    { "children": [], "name": "Authenticated" }
+  ],
+  "type": "AllOf"
+},
+"readPermissions": {
+  "securityLevels": [
+    { "children": [], "name": "Authenticated" }
+  ],
+  "type": "AllOf"
+},
+"writePermissions": {
+  "securityLevels": [
+    { "children": [], "name": "Authenticated" }
+  ],
+  "type": "AllOf"
+}
 ```
 
 Then restart the Gateway:
@@ -106,7 +126,16 @@ Then restart the Gateway:
 docker compose restart gateway
 ```
 
-Once both steps are complete, the Gateway requires a valid login for any access.
+Once both steps are complete, the Gateway requires a valid login for any access:
+anonymous visits to `/app/home`, `/app/platform/security/user-sources`, and the rest of
+the Gateway UI return a "Not Authenticated" prompt or "Page Not Found".
+
+> [!NOTE]
+> `forceIdpAuth` (also in `security-properties/config.json`) does **not** control whether
+> login is required. Per the Ignition docs it controls SSO behavior: when `true`, the
+> Gateway always asks the IdP to re-authenticate the user by default, effectively
+> disabling Single Sign-On. Flipping it does not open or close anonymous access on its
+> own; the permission blocks above are what gate access.
 
 ## Linting
 

--- a/README.md
+++ b/README.md
@@ -79,56 +79,13 @@ the Designer).
 
 ### Locking the Gateway Down
 
-Before deploying this template anywhere that is not your local machine, complete both steps
-below.
+Before deploying this template anywhere that is not your local machine, do both of the
+following from the Gateway web UI:
 
-**1. Change the admin password.**
-
-- Open the Gateway in your browser.
-- In the left nav, go to `Platform` -> expand `Security` -> `User Sources`.
-- On the `default` user source row, click the kebab (`show-more`) menu and choose
-  `Manage Users`.
-- In the drawer that opens, click the kebab on the `admin` row and choose `Edit`.
-- Tick `Change Password`, enter the new password in both fields, and click `Save Changes`.
-- Commit the updated `users.json` if you want the new credential baked into the template,
-  or leave it in the runtime volume.
-
-**2. Require authentication on the Gateway.**
-
-Edit `services/ignition/config/resources/core/ignition/security-properties/config.json` and
-replace the three permission blocks (`accessPermissions`, `readPermissions`,
-`writePermissions`) so they require the `Authenticated` security level:
-
-```json
-"accessPermissions": {
-  "securityLevels": [
-    { "children": [], "name": "Authenticated" }
-  ],
-  "type": "AllOf"
-},
-"readPermissions": {
-  "securityLevels": [
-    { "children": [], "name": "Authenticated" }
-  ],
-  "type": "AllOf"
-},
-"writePermissions": {
-  "securityLevels": [
-    { "children": [], "name": "Authenticated" }
-  ],
-  "type": "AllOf"
-}
-```
-
-Then restart the Gateway:
-
-```shell
-docker compose restart gateway
-```
-
-Once both steps are complete, the Gateway requires a valid login for any access:
-anonymous visits to `/app/home`, `/app/platform/security/user-sources`, and the rest of
-the Gateway UI return a "Not Authenticated" prompt or "Page Not Found".
+1. Change the `admin` password under `Platform -> Security -> User Sources -> default`.
+2. Set the `Access`, `Read`, and `Write` permissions under
+   `Platform -> Security -> Gateway General Security Settings` to require the
+   `Authenticated` security level.
 
 ## Linting
 

--- a/README.md
+++ b/README.md
@@ -79,13 +79,9 @@ the Designer).
 
 ### Locking the Gateway Down
 
-Before deploying this template anywhere that is not your local machine, do both of the
-following from the Gateway web UI:
-
-1. Change the `admin` password under `Platform -> Security -> User Sources -> default`.
-2. Set the `Access`, `Read`, and `Write` permissions under
-   `Platform -> Security -> Gateway General Security Settings` to require the
-   `Authenticated` security level.
+Before any non-local deployment, change the `admin` password and require the
+`Authenticated` security level on the Gateway's Access/Read/Write permissions. Both
+are under `Platform -> Security` in the Gateway web UI.
 
 ## Linting
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,56 @@ The two bind-mounted directories in your repo are tracked in Git:
 
 Changes made in the Ignition Designer appear instantly in these directories - no export step needed.
 
+## Security
+
+By design, this template ships with the Gateway open: no login is required to browse the
+Gateway UI. This avoids the situation where a new user clones the template, brings the stack
+up, and has no way to know what credentials to use.
+
+The committed admin user still exists in
+`services/ignition/config/resources/core/ignition/user-source/default/users.json`. You only
+need to authenticate for operations that require an `Administrator` role (such as launching
+the Designer).
+
+> [!WARNING]
+> While `forceIdpAuth` is `false`, the user-management UI is also unauthenticated. Anyone
+> with network access to the Gateway can change the `admin` password through the UI without
+> first proving they know the existing one. Treat the open-by-default Gateway as a local
+> development convenience only.
+
+### Locking the Gateway Down
+
+Before deploying this template anywhere that is not your local machine, complete both steps
+below.
+
+**1. Change the admin password.**
+
+- Open the Gateway in your browser.
+- In the left nav, go to `Platform` -> expand `Security` -> `User Sources`.
+- On the `default` user source row, click the kebab (`show-more`) menu and choose
+  `Manage Users`.
+- In the drawer that opens, click the kebab on the `admin` row and choose `Edit`.
+- Tick `Change Password`, enter the new password in both fields, and click `Save Changes`.
+- Commit the updated `users.json` if you want the new credential baked into the template,
+  or leave it in the runtime volume.
+
+**2. Re-enable authentication enforcement.**
+
+Edit `services/ignition/config/resources/core/ignition/security-properties/config.json` and
+set:
+
+```json
+"forceIdpAuth": true
+```
+
+Then restart the Gateway:
+
+```shell
+docker compose restart gateway
+```
+
+Once both steps are complete, the Gateway requires a valid login for any access.
+
 ## Linting
 
 Pull requests run shellcheck, markdownlint, yamllint, and ignition-lint automatically. See the

--- a/services/ignition/config/resources/core/ignition/security-properties/config.json
+++ b/services/ignition/config/resources/core/ignition/security-properties/config.json
@@ -33,7 +33,7 @@
     "type": "AnyOf"
   },
   "designerRoleName": "Administrator",
-  "forceIdpAuth": true,
+  "forceIdpAuth": false,
   "gatewayAuditProfile": "",
   "readPermissions": {
     "securityLevels": [],

--- a/services/ignition/config/resources/core/ignition/security-properties/config.json
+++ b/services/ignition/config/resources/core/ignition/security-properties/config.json
@@ -33,7 +33,7 @@
     "type": "AnyOf"
   },
   "designerRoleName": "Administrator",
-  "forceIdpAuth": false,
+  "forceIdpAuth": true,
   "gatewayAuditProfile": "",
   "readPermissions": {
     "securityLevels": [],


### PR DESCRIPTION
## Summary

Empirical testing showed that PR #33's GATEWAY_ADMIN_USERNAME / GATEWAY_ADMIN_PASSWORD env vars do not actually work in this image. `commissioning.json = {}` (required for the auto-commissioning pattern) short-circuits the commissioning subsystem that consumes those env vars.

This PR documents how the Gateway already behaves out of the box: open by default. The shipped `security-properties/config.json` has empty `accessPermissions`/`readPermissions`/`writePermissions` (`AnyOf` with no levels), so anonymous users can browse the entire Gateway UI without logging in. The committed admin user is still available for privileged operations like launching the Designer.

## Changes

- README: new Security section explaining the open-by-default behavior and short lockdown instructions (change admin password + require the `Authenticated` security level on Access/Read/Write permissions, both in the Gateway web UI).

No changes to `security-properties/config.json` — the file already ships open.

## Replaces

PR #33 (add admin credentials env vars). Closing that PR; this is the actual fix.