### PR TITLE
fix stale ignition-guides links

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,11 @@ instructions.
 
 5. Open `http://${GATEWAY_NAME}.localtest.me` in your browser
 
-For a full walkthrough see the [Version Control Lab](https://ia-eknorr.github.io/ignition-guides/docs/labs/version-control-lab).
+For step-by-step walkthroughs using this template, see ignition-guides:
+
+- [Docker Lab](https://ia-eknorr.github.io/ignition-guides/docs/labs/docker-ignition-lab) - start here. Bring the gateway up, watch each service boot, and practice day-two operations.
+- [Version Control Lab](https://ia-eknorr.github.io/ignition-guides/docs/labs/version-control-lab) - track this project in Git with branches, pull requests, and merges.
+- [Helm Lab](https://ia-eknorr.github.io/ignition-guides/docs/labs/helm-ignition-lab) - deploy Ignition to a local Kubernetes cluster using the official Helm chart.
 
 ## Version Control
 

--- a/README.md
+++ b/README.md
@@ -89,5 +89,4 @@ are under `Platform -> Security` in the Gateway web UI.
 
 ## Linting
 
-Pull requests run shellcheck, markdownlint, yamllint, and ignition-lint automatically. See the
-[ignition-guides](https://ia-eknorr.github.io/ignition-guides/) for details.
+Pull requests run [shellcheck](https://www.shellcheck.net/), [markdownlint](https://github.com/DavidAnson/markdownlint), [yamllint](https://yamllint.readthedocs.io/), and [ignition-lint](https://ia-eknorr.github.io/ignition-guides/docs/tools/ignition-lint) automatically. To run them locally before pushing, install [pre-commit](https://pre-commit.com/) and run `pre-commit run --all-files`. The configuration lives in `.pre-commit-config.yaml`.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ instructions.
 
 5. Open `http://${GATEWAY_NAME}.localtest.me` in your browser
 
-For a full walkthrough see the [Hands-On Lab](https://ia-eknorr.github.io/ignition-guides/docs/labs/git-ignition-lab).
+For a full walkthrough see the [Version Control Lab](https://ia-eknorr.github.io/ignition-guides/docs/labs/version-control-lab).
 
 ## Version Control
 


### PR DESCRIPTION
The Phase 1 work on ignition-guides renamed `git-ignition-lab` to `version-control-lab` and the Phase 2 work added a Docker Lab and Helm Lab. The README also had a weak lint pointer that just said "see the ignition-guides for details."

This PR:
- Fixes the stale `git-ignition-lab` link
- Expands the README's lab pointer from a single Version Control Lab link to a short list of all three labs (Docker Lab as the primary entry point, then Version Control Lab, then Helm Lab)
- Improves the lint paragraph to link each linter to its canonical docs and tell readers how to run pre-commit locally

Independent of PR #35 (add license).